### PR TITLE
feat: implement ISR (Incremental Static Regeneration)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ NEXT_PUBLIC_VERCEL_URL="https://fw-commerce.vercel.app"
 # Optional
 NEXT_PUBLIC_FW_COLLECTION="launch"
 NEXT_PUBLIC_FW_API_URL="https://storefront-api.fourthwall.com"
+
+# ISR Revalidation
+REVALIDATE_SECRET="your-secret-token-here"

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,37 @@
+import { revalidateTag, revalidatePath } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server';
+import { TAGS } from 'lib/constants';
+
+// Cache life profile for immediate revalidation
+const IMMEDIATE_REVALIDATE = { expire: 0 };
+
+export async function POST(request: NextRequest) {
+  const secret = request.headers.get('x-revalidate-secret');
+
+  if (secret !== process.env.REVALIDATE_SECRET) {
+    return NextResponse.json({ error: 'Invalid secret' }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { tag, path } = body;
+
+    if (tag && Object.values(TAGS).includes(tag)) {
+      revalidateTag(tag, IMMEDIATE_REVALIDATE);
+      return NextResponse.json({ revalidated: true, tag });
+    }
+
+    if (path) {
+      revalidatePath(path);
+      return NextResponse.json({ revalidated: true, path });
+    }
+
+    // Default: revalidate all product-related content
+    revalidateTag(TAGS.products, IMMEDIATE_REVALIDATE);
+    revalidateTag(TAGS.collections, IMMEDIATE_REVALIDATE);
+    return NextResponse.json({ revalidated: true, tags: [TAGS.products, TAGS.collections] });
+
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to revalidate' }, { status: 500 });
+  }
+}

--- a/app/collections/[handle]/page.tsx
+++ b/app/collections/[handle]/page.tsx
@@ -4,7 +4,14 @@ import Collections from "components/layout/collections";
 import Footer from "components/layout/footer";
 import ProductGridItems from "components/layout/product-grid-items";
 import { Wrapper } from "components/wrapper";
-import { getCart, getCollectionProducts } from "lib/fourthwall";
+import { getCart, getCollectionProducts, getCollections } from "lib/fourthwall";
+
+export const revalidate = 3600; // 1 hour in seconds
+
+export async function generateStaticParams() {
+  const collections = await getCollections();
+  return collections.map(({ handle }) => ({ handle }));
+}
 
 export default async function CategoryPage({
   params,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,8 @@ import Footer from 'components/layout/footer';
 import { Wrapper } from 'components/wrapper';
 import { getCart } from 'lib/fourthwall';
 
+export const revalidate = 3600; // 1 hour in seconds
+
 export const metadata = {
   description: 'High-performance ecommerce store built with Next.js, Vercel, and Fourthwall.',
   openGraph: {

--- a/app/product/[handle]/page.tsx
+++ b/app/product/[handle]/page.tsx
@@ -8,8 +8,15 @@ import { ProductProvider } from 'components/product/product-context';
 import { ProductDescription } from 'components/product/product-description';
 import { Wrapper } from 'components/wrapper';
 import { HIDDEN_PRODUCT_TAG } from 'lib/constants';
-import { getCart, getProduct } from 'lib/fourthwall';
+import { getCart, getProduct, getProducts } from 'lib/fourthwall';
 import { Suspense } from 'react';
+
+export const revalidate = 3600; // 1 hour in seconds
+
+export async function generateStaticParams() {
+  const products = await getProducts();
+  return products.map(({ handle }) => ({ handle }));
+}
 
 export async function generateMetadata({
   params


### PR DESCRIPTION
- Add revalidate=3600 (1 hour) to homepage, product, and collection pages
- Add generateStaticParams for product and collection routes to pre-build at deploy
- Add cache tags to Fourthwall API fetches for selective invalidation
- Add /api/revalidate webhook endpoint for on-demand cache invalidation
- Add REVALIDATE_SECRET env var for webhook authentication