### PR TITLE
DP-162: Add Fourthwall image optimization alternative

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ NEXT_PUBLIC_VERCEL_URL="https://fw-commerce.vercel.app"
 # Optional
 NEXT_PUBLIC_FW_COLLECTION="launch"
 NEXT_PUBLIC_FW_API_URL="https://storefront-api.fourthwall.com"
+
+# Image Optimization: Use Fourthwall's image optimization instead of Vercel's
+# NEXT_PUBLIC_USE_FW_IMAGE_OPTIMIZATION="true"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ vercel env add NEXT_PUBLIC_VERCEL_URL
 vercel --prod # Deploys to production
 ```
 
+## Image Optimization
+
+By default, this template uses Vercel's Image Optimization. To use Fourthwall's built-in image optimization instead, set:
+
+```bash
+NEXT_PUBLIC_USE_FW_IMAGE_OPTIMIZATION="true"
+```
+
 ## Resources
 
 * How to get your [collection handle](https://docs.fourthwall.com/storefront/collection).

--- a/components/carousel.tsx
+++ b/components/carousel.tsx
@@ -31,6 +31,7 @@ export async function Carousel({currency}: {currency: string}) {
                   currencyCode: product.priceRange.maxVariantPrice.currencyCode
                 }}
                 src={product.featuredImage?.url}
+                transformedSrc={product.featuredImage?.transformedUrl}
                 fill
                 sizes="(min-width: 1024px) 25vw, (min-width: 768px) 33vw, 50vw"
               />

--- a/components/cart/modal.tsx
+++ b/components/cart/modal.tsx
@@ -6,7 +6,7 @@ import LoadingDots from 'components/loading-dots';
 import Price from 'components/price';
 import { DEFAULT_OPTION } from 'lib/constants';
 import { createUrl } from 'lib/utils';
-import Image from 'next/image';
+import { ProductImage } from 'components/product-image';
 import Link from 'next/link';
 import { Fragment, useEffect, useRef, useState } from 'react';
 import { useFormStatus } from 'react-dom';
@@ -113,7 +113,7 @@ export default function CartModal() {
                               </div>
                               <div className="flex flex-row">
                                 <div className="relative h-16 w-16 overflow-hidden rounded-md border border-neutral-300 bg-neutral-300 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:bg-neutral-800">
-                                  <Image
+                                  <ProductImage
                                     className="h-full w-full object-cover"
                                     width={64}
                                     height={64}
@@ -122,6 +122,7 @@ export default function CartModal() {
                                       item.merchandise.product.title
                                     }
                                     src={item.merchandise.product.featuredImage.url}
+                                    transformedSrc={item.merchandise.product.featuredImage.transformedUrl}
                                   />
                                 </div>
                                 <Link

--- a/components/grid/three-items.tsx
+++ b/components/grid/three-items.tsx
@@ -25,6 +25,7 @@ function ThreeItemGridItem({
       >
         <GridTileImage
           src={item.featuredImage.url}
+          transformedSrc={item.featuredImage.transformedUrl}
           fill
           sizes={
             size === 'full' ? '(min-width: 768px) 66vw, 100vw' : '(min-width: 768px) 33vw, 100vw'

--- a/components/grid/tile.tsx
+++ b/components/grid/tile.tsx
@@ -2,10 +2,13 @@ import clsx from 'clsx';
 import Image from 'next/image';
 import Label from '../label';
 
+const useFourthwallImages = process.env.NEXT_PUBLIC_USE_FW_IMAGE_OPTIMIZATION === 'true';
+
 export function GridTileImage({
   isInteractive = true,
   active,
   label,
+  transformedSrc,
   ...props
 }: {
   isInteractive?: boolean;
@@ -16,7 +19,12 @@ export function GridTileImage({
     currencyCode: string;
     position?: 'bottom' | 'center';
   };
+  transformedSrc?: string;
 } & React.ComponentProps<typeof Image>) {
+  const imageClassName = clsx('relative h-full w-full object-contain', {
+    'transition duration-300 ease-in-out group-hover:scale-105': isInteractive
+  });
+
   return (
     <div
       className={clsx(
@@ -29,12 +37,21 @@ export function GridTileImage({
       )}
     >
       {props.src ? (
-        <Image
-          className={clsx('relative h-full w-full object-contain', {
-            'transition duration-300 ease-in-out group-hover:scale-105': isInteractive
-          })}
-          {...props}
-        />
+        useFourthwallImages && transformedSrc ? (
+          <img
+            src={transformedSrc}
+            alt={props.alt as string}
+            className={imageClassName}
+            width={props.width as number}
+            height={props.height as number}
+            loading={props.priority ? 'eager' : 'lazy'}
+          />
+        ) : (
+          <Image
+            className={imageClassName}
+            {...props}
+          />
+        )
       ) : null}
       {label ? (
         <Label

--- a/components/layout/product-grid-items.tsx
+++ b/components/layout/product-grid-items.tsx
@@ -21,6 +21,7 @@ export default function ProductGridItems({ products }: { products: Product[] }) 
                 currencyCode: product.priceRange.maxVariantPrice.currencyCode
               }}
               src={product.featuredImage?.url}
+              transformedSrc={product.featuredImage?.transformedUrl}
               fill
               sizes="(min-width: 768px) 33vw, (min-width: 640px) 50vw, 100vw"
             />

--- a/components/product-image.tsx
+++ b/components/product-image.tsx
@@ -1,0 +1,54 @@
+import clsx from 'clsx';
+import Image from 'next/image';
+
+const useFourthwallImages = process.env.NEXT_PUBLIC_USE_FW_IMAGE_OPTIMIZATION === 'true';
+
+type ProductImageProps = {
+  src: string;
+  transformedSrc: string;
+  alt: string;
+  className?: string;
+  fill?: boolean;
+  width?: number;
+  height?: number;
+  sizes?: string;
+  priority?: boolean;
+};
+
+export function ProductImage({
+  src,
+  transformedSrc,
+  alt,
+  className,
+  fill,
+  width,
+  height,
+  sizes,
+  priority
+}: ProductImageProps) {
+  if (useFourthwallImages) {
+    return (
+      <img
+        src={transformedSrc}
+        alt={alt}
+        className={clsx(className, { 'absolute inset-0': fill })}
+        width={width}
+        height={height}
+        loading={priority ? 'eager' : 'lazy'}
+      />
+    );
+  }
+
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      className={className}
+      fill={fill}
+      width={width}
+      height={height}
+      sizes={sizes}
+      priority={priority}
+    />
+  );
+}

--- a/components/product/gallery.tsx
+++ b/components/product/gallery.tsx
@@ -2,9 +2,9 @@
 
 import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
 import { GridTileImage } from 'components/grid/tile';
+import { ProductImage } from 'components/product-image';
 import { useProduct, useUpdateURL } from 'components/product/product-context';
 import { Product } from 'lib/types';
-import Image from 'next/image';
 
 export function Gallery({ product }: { product: Product }) {
   const { state, updateImage } = useProduct();
@@ -27,12 +27,13 @@ export function Gallery({ product }: { product: Product }) {
     <form>
       <div className="relative aspect-square h-full max-h-[550px] w-full overflow-hidden">
         {images[imageIndex] && (
-          <Image
+          <ProductImage
             className="h-full w-full object-contain"
             fill
             sizes="(min-width: 1024px) 66vw, 100vw"
             alt={images[imageIndex]?.altText as string}
             src={images[imageIndex]?.url as string}
+            transformedSrc={images[imageIndex]?.transformedUrl as string}
             priority={true}
           />
         )}
@@ -84,6 +85,7 @@ export function Gallery({ product }: { product: Product }) {
                   <GridTileImage
                     alt={image.altText}
                     src={image.url}
+                    transformedSrc={image.transformedUrl}
                     width={80}
                     height={80}
                     active={isActive}

--- a/lib/fourthwall/reshape.ts
+++ b/lib/fourthwall/reshape.ts
@@ -6,6 +6,7 @@ import { FourthwallCart, FourthwallCartItem, FourthwallMoney, FourthwallProduct,
  */
 const DEFAULT_IMAGE: Image = {
   url: '',
+  transformedUrl: '',
   altText: '',
   width: 0,
   height: 0
@@ -94,7 +95,10 @@ const reshapeImages = (images: FourthwallProductImage[], productTitle: string): 
   return images.map((image) => {
     const filename = image.url.match(/.*\/(.*)\..*/)?.[1];
     return {
-      ...image,
+      url: image.url,
+      transformedUrl: image.transformedUrl,
+      width: image.width,
+      height: image.height,
       altText: `${productTitle} - ${filename}`
     };
   });
@@ -142,6 +146,7 @@ const reshapeCartItem = (item: FourthwallCartItem): CartItem => {
         title: item.variant.product?.name || 'TT',
         featuredImage: {
           url: item.variant.images[0]?.url || 'TT',
+          transformedUrl: item.variant.images[0]?.transformedUrl || 'TT',
           altText: item.variant.product?.name || 'TT',
           width: item.variant.images[0]?.width || 100,
           height: item.variant.images[0]?.height || 100

--- a/lib/fourthwall/types.ts
+++ b/lib/fourthwall/types.ts
@@ -26,6 +26,7 @@ export type FourthwallProduct = {
 export type FourthwallProductImage = {
   id: string;
   url: string;
+  transformedUrl: string;
   width: number;
   height: number;
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -41,6 +41,7 @@ export type Collection = {
 
 export type Image = {
   url: string;
+  transformedUrl: string;
   altText: string;
   width: number;
   height: number;


### PR DESCRIPTION
Add configuration option to use Fourthwall's pre-optimized images (transformedUrl) instead of Vercel's Image Optimization service.

When NEXT_PUBLIC_USE_FW_IMAGE_OPTIMIZATION=true is set, the app renders standard <img> tags with transformedUrl instead of using Next.js <Image> component with Vercel optimization.

Changes:
- Add transformedUrl field to image types
- Create ProductImage wrapper component
- Update GridTileImage, Gallery, and Cart modal
- Add env var documentation