### PR TITLE
fix test config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,7 @@
 import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react';
 import path from 'path';
 
 export default defineConfig({
-  plugins: [react()],
   test: {
     environment: 'node',
     globals: true,


### PR DESCRIPTION
Remove unused @vitejs/plugin-react from vitest config (not needed for API route tests)