### PR TITLE
ISR webhook invalidation [DP-180]

### DIFF
--- a/app/[currency]/collections/[handle]/page.tsx
+++ b/app/[currency]/collections/[handle]/page.tsx
@@ -4,7 +4,7 @@ import Collections from "components/layout/collections";
 import Footer from "components/layout/footer";
 import ProductGridItems from "components/layout/product-grid-items";
 import { Wrapper } from "components/wrapper";
-import { getCollectionProducts, getShop, getShopOgImage } from "lib/fourthwall";
+import { getCollectionProducts, getCollections, getShop, getShopOgImage } from "lib/fourthwall";
 
 export const revalidate = 3600;
 
@@ -49,16 +49,17 @@ export default async function CategoryPage({
   params: Promise<{ currency: string; handle: string }>;
 }) {
   const { currency, handle } = await params;
-  const [products, shop] = await Promise.all([
+  const [products, shop, collections] = await Promise.all([
     getCollectionProducts({ collection: handle, currency, limit: 5 }),
-    getShop()
+    getShop(),
+    getCollections()
   ]);
 
   return (
     <Wrapper currency={currency} shop={shop}>
       <div className="mx-auto flex max-w-screen-2xl flex-col gap-8 px-4 pb-4 text-black dark:text-white md:flex-row">
         <div className="order-first w-full flex-none md:max-w-[125px]">
-          <Collections />
+          <Collections collections={collections} />
         </div>
         <div className="order-last min-h-screen w-full md:order-none">
           <section>

--- a/app/api/webhooks/fourthwall/__tests__/route.test.ts
+++ b/app/api/webhooks/fourthwall/__tests__/route.test.ts
@@ -63,7 +63,7 @@ describe('Fourthwall Webhook Route', () => {
       expect(response.status).toBe(200);
       expect(data.revalidated).toBe(true);
       expect(data.tags).toContain('product-test-product');
-      expect(revalidateTag).toHaveBeenCalledWith('product-test-product', 'default');
+      expect(revalidateTag, 'max').toHaveBeenCalledWith('product-test-product');
     });
   });
 
@@ -84,7 +84,7 @@ describe('Fourthwall Webhook Route', () => {
 
       expect(response.status).toBe(401);
       expect(data.error).toBe('Invalid signature');
-      expect(revalidateTag).not.toHaveBeenCalled();
+      expect(revalidateTag, 'max').not.toHaveBeenCalled();
     });
   });
 
@@ -102,7 +102,7 @@ describe('Fourthwall Webhook Route', () => {
 
       expect(response.status).toBe(401);
       expect(data.error).toBe('Invalid signature');
-      expect(revalidateTag).not.toHaveBeenCalled();
+      expect(revalidateTag, 'max').not.toHaveBeenCalled();
     });
   });
 
@@ -124,7 +124,7 @@ describe('Fourthwall Webhook Route', () => {
 
       expect(response.status).toBe(200);
       expect(data.tags).toEqual(['product-awesome-shirt']);
-      expect(revalidateTag).toHaveBeenCalledWith('product-awesome-shirt', 'default');
+      expect(revalidateTag, 'max').toHaveBeenCalledWith('product-awesome-shirt');
     });
 
     it('should invalidate product-{slug} tag for PRODUCT_CREATED', async () => {
@@ -144,7 +144,7 @@ describe('Fourthwall Webhook Route', () => {
 
       expect(response.status).toBe(200);
       expect(data.tags).toEqual(['product-new-product']);
-      expect(revalidateTag).toHaveBeenCalledWith('product-new-product', 'default');
+      expect(revalidateTag, 'max').toHaveBeenCalledWith('product-new-product');
     });
   });
 
@@ -166,7 +166,7 @@ describe('Fourthwall Webhook Route', () => {
 
       expect(response.status).toBe(200);
       expect(data.tags).toEqual(['collection-summer-collection']);
-      expect(revalidateTag).toHaveBeenCalledWith('collection-summer-collection', 'default');
+      expect(revalidateTag, 'max').toHaveBeenCalledWith('collection-summer-collection');
     });
 
   });
@@ -190,7 +190,7 @@ describe('Fourthwall Webhook Route', () => {
       expect(response.status).toBe(200);
       expect(data.revalidated).toBe(false);
       expect(data.reason).toBe('No tags to invalidate');
-      expect(revalidateTag).not.toHaveBeenCalled();
+      expect(revalidateTag, 'max').not.toHaveBeenCalled();
     });
   });
 
@@ -212,7 +212,7 @@ describe('Fourthwall Webhook Route', () => {
 
       expect(response.status).toBe(400);
       expect(data.error).toBe('Missing webhook secret configuration');
-      expect(revalidateTag).not.toHaveBeenCalled();
+      expect(revalidateTag, 'max').not.toHaveBeenCalled();
     });
   });
 
@@ -235,7 +235,7 @@ describe('Fourthwall Webhook Route', () => {
       expect(response.status).toBe(200);
       expect(data.revalidated).toBe(false);
       expect(data.reason).toBe('No tags to invalidate');
-      expect(revalidateTag).not.toHaveBeenCalled();
+      expect(revalidateTag, 'max').not.toHaveBeenCalled();
     });
   });
 
@@ -258,7 +258,7 @@ describe('Fourthwall Webhook Route', () => {
 
       expect(response.status).toBe(400);
       expect(data.error).toBe('Invalid payload');
-      expect(revalidateTag).not.toHaveBeenCalled();
+      expect(revalidateTag, 'max').not.toHaveBeenCalled();
     });
   });
 });

--- a/app/api/webhooks/fourthwall/route.ts
+++ b/app/api/webhooks/fourthwall/route.ts
@@ -117,7 +117,7 @@ export async function POST(request: NextRequest) {
   try {
     for (const tag of tags) {
       console.log('[Webhook] Revalidating tag:', tag);
-      revalidateTag(tag, 'default');
+      revalidateTag(tag, 'max');
     }
 
     return NextResponse.json({

--- a/components/layout/collections.tsx
+++ b/components/layout/collections.tsx
@@ -1,11 +1,9 @@
 'use client';
 
 import clsx from "clsx";
-import { getCollections } from "lib/fourthwall";
 import { Collection } from "lib/types";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
-import { Suspense } from "react";
 
 function createUrl(handle: string) {
   return `/collections/${handle}`;
@@ -56,34 +54,6 @@ export function FilterList({ list, title }: { list: Collection[]; title?: string
   );
 }
 
-async function CollectionList() {
-  const collections = await getCollections();
+export default function Collections({ collections }: { collections: Collection[] }) {
   return <FilterList list={collections} title="Collections" />;
-}
-
-const skeleton = 'mb-3 h-4 w-5/6 animate-pulse rounded';
-const activeAndTitles = 'bg-neutral-800 dark:bg-neutral-300';
-const items = 'bg-neutral-400 dark:bg-neutral-700';
-
-export default function Collections() {
-  return (
-    <Suspense
-      fallback={
-        <div className="col-span-2 hidden h-[400px] w-full flex-none py-4 lg:block">
-          <div className={clsx(skeleton, activeAndTitles)} />
-          <div className={clsx(skeleton, activeAndTitles)} />
-          <div className={clsx(skeleton, items)} />
-          <div className={clsx(skeleton, items)} />
-          <div className={clsx(skeleton, items)} />
-          <div className={clsx(skeleton, items)} />
-          <div className={clsx(skeleton, items)} />
-          <div className={clsx(skeleton, items)} />
-          <div className={clsx(skeleton, items)} />
-          <div className={clsx(skeleton, items)} />
-        </div>
-      }
-    >
-      <CollectionList />
-    </Suspense>
-  );
 }


### PR DESCRIPTION
## Summary
- Add Fourthwall webhook endpoint for ISR cache invalidation
- Remove manual /api/revalidate endpoint
- Fix Collections component (was causing infinite loop due to client/server mixing)
- Use correct revalidateTag signature with "max" argument

## Changes
- `app/api/webhooks/fourthwall/route.ts` - New webhook endpoint with HMAC verification
- `components/layout/collections.tsx` - Fix client/server component pattern
- `app/[currency]/collections/[handle]/page.tsx` - Fetch collections server-side
- Remove COLLECTION_CREATED and COLLECTION_DELETED event types
- Add vitest tests for webhook endpoint