### PR TITLE
Restrict remotePatterns to specific fourthwall hosts

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,8 +5,15 @@ module.exports = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: '**',
-        pathname: '**'
+        hostname: '*.fourthwall.com',
+        port: '',
+        search: '',
+      },
+      {
+        protocol: 'https',
+        hostname: '*.fourthwall.dev',
+        port: '',
+        search: '',
       }
     ]
   },


### PR DESCRIPTION
explicitly list supported hostnames